### PR TITLE
fix:  metrics 

### DIFF
--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -586,15 +586,17 @@ func podMetricFamilies(allowLabelsList []string) []generator.FamilyGenerator {
 			"",
 			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
+				if _, ok := p.Labels["volcano.sh/job-name"]; ok {
 
-				for i, cs := range p.Status.ContainerStatuses {
-					ms[i] = &metric.Metric{
-						LabelKeys:   []string{"container", "job_name", "queue"},
-						LabelValues: []string{cs.Name, p.Labels["volcano.sh/job-name"], p.Labels["volcano.sh/queue-name"]},
-						Value:       boolFloat64(cs.State.Running != nil),
+					for i, cs := range p.Status.ContainerStatuses {
+						ms[i] = &metric.Metric{
+							LabelKeys:   []string{"container", "job_name", "queue"},
+							LabelValues: []string{cs.Name, p.Labels["volcano.sh/job-name"], p.Labels["volcano.sh/queue-name"]},
+							Value:       boolFloat64(cs.State.Running != nil),
+						}
 					}
-				}
 
+				}
 				return &metric.Family{
 					Metrics: ms,
 				}
@@ -906,49 +908,50 @@ func podMetricFamilies(allowLabelsList []string) []generator.FamilyGenerator {
 			"",
 			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
+				if _, ok := p.Labels["volcano.sh/job-name"]; ok {
 
-				for _, c := range p.Spec.Containers {
-					req := c.Resources.Requests
+					for _, c := range p.Spec.Containers {
+						req := c.Resources.Requests
 
-					for resourceName, val := range req {
-						switch resourceName {
-						case v1.ResourceCPU:
-							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, p.Spec.NodeName, p.Namespace, p.Labels["volcano.sh/job-name"], p.Labels["volcano.sh/queue-name"], sanitizeLabelName(string(resourceName)), string(constant.UnitCore)},
-								Value:       float64(val.MilliValue()) / 1000,
-							})
-						case v1.ResourceStorage:
-							fallthrough
-						case v1.ResourceEphemeralStorage:
-							fallthrough
-						case v1.ResourceMemory:
-							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, p.Spec.NodeName, p.Namespace, p.Labels["volcano.sh/job-name"], p.Labels["volcano.sh/queue-name"], sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
-								Value:       float64(val.Value()),
-							})
-						default:
-							if isHugePageResourceName(resourceName) {
+						for resourceName, val := range req {
+							switch resourceName {
+							case v1.ResourceCPU:
+								ms = append(ms, &metric.Metric{
+									LabelValues: []string{c.Name, p.Spec.NodeName, p.Namespace, p.Labels["volcano.sh/job-name"], p.Labels["volcano.sh/queue-name"], sanitizeLabelName(string(resourceName)), string(constant.UnitCore)},
+									Value:       float64(val.MilliValue()) / 1000,
+								})
+							case v1.ResourceStorage:
+								fallthrough
+							case v1.ResourceEphemeralStorage:
+								fallthrough
+							case v1.ResourceMemory:
 								ms = append(ms, &metric.Metric{
 									LabelValues: []string{c.Name, p.Spec.NodeName, p.Namespace, p.Labels["volcano.sh/job-name"], p.Labels["volcano.sh/queue-name"], sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
 									Value:       float64(val.Value()),
 								})
-							}
-							if isAttachableVolumeResourceName(resourceName) {
-								ms = append(ms, &metric.Metric{
-									LabelValues: []string{c.Name, p.Spec.NodeName, p.Namespace, p.Labels["volcano.sh/job-name"], p.Labels["volcano.sh/queue-name"], sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
-									Value:       float64(val.Value()),
-								})
-							}
-							if isExtendedResourceName(resourceName) {
-								ms = append(ms, &metric.Metric{
-									LabelValues: []string{c.Name, p.Spec.NodeName, p.Namespace, p.Labels["volcano.sh/job-name"], p.Labels["volcano.sh/queue-name"], sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
-									Value:       float64(val.Value()),
-								})
+							default:
+								if isHugePageResourceName(resourceName) {
+									ms = append(ms, &metric.Metric{
+										LabelValues: []string{c.Name, p.Spec.NodeName, p.Namespace, p.Labels["volcano.sh/job-name"], p.Labels["volcano.sh/queue-name"], sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+										Value:       float64(val.Value()),
+									})
+								}
+								if isAttachableVolumeResourceName(resourceName) {
+									ms = append(ms, &metric.Metric{
+										LabelValues: []string{c.Name, p.Spec.NodeName, p.Namespace, p.Labels["volcano.sh/job-name"], p.Labels["volcano.sh/queue-name"], sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+										Value:       float64(val.Value()),
+									})
+								}
+								if isExtendedResourceName(resourceName) {
+									ms = append(ms, &metric.Metric{
+										LabelValues: []string{c.Name, p.Spec.NodeName, p.Namespace, p.Labels["volcano.sh/job-name"], p.Labels["volcano.sh/queue-name"], sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
+										Value:       float64(val.Value()),
+									})
+								}
 							}
 						}
 					}
 				}
-
 				for _, metric := range ms {
 					metric.LabelKeys = []string{"container", "node", "volcano_namespace", "volcano_job", "queue", "resource", "unit"}
 				}


### PR DESCRIPTION
in my actual use, I found that some pods  without the 'volcano.sh/job-name' label also send 'kube_pod_volcano_container_resource_requests' and 'kube_pod_volcano_container_status_running' metrics to prometheus server. 
```
kube_pod_volcano_container_resource_requests{
container="kube-state-metrics", 
endpoint="http-metrics", 
exported_container="etcd", 
exported_namespace="kube-system",
 exported_pod="etcd-ecs-165944-0001", 
instance="10.32.0.17:8080", job="kube-state-metrics", namespace="volcano-system", node="ecs-165944-0001", 
pod="kube-state-metrics-6769bc86fd-t42fk", 
resource="memory", service="kube-state-metrics",
 uid="4c151a5e-c0bb-47a4-be22-f734e1cbf295", unit="byte", volcano_namespace="kube-system"}
```
Therefore, based on the processing logic of metric 'kube_pod_volcano_container_resource_limits', i add the same pod label filtering for those two metrics as the 'kube_pod_volcano_container_resource_limits' do.